### PR TITLE
Remove markup from entry keys

### DIFF
--- a/BibLaTeX.js
+++ b/BibLaTeX.js
@@ -15,7 +15,7 @@
 		"exportFileData": false,
 		"useJournalAbbreviation": false
 	},
-	"lastUpdated": "2016-06-21 08:45:20"
+	"lastUpdated": "2017-08-28 10:55:00"
 }
 
 
@@ -344,7 +344,7 @@ var numberRe = /^[0-9]+/;
 // in includes the indefinite articles of English, German, French and Spanish, as well as a small set of English prepositions whose
 // force is more grammatical than lexical, i.e. which are likely to strike many as 'insignificant'.
 // The assumption is that most who want a title word in their key would prefer the first word of significance.
-var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l\'|el|las|los|al|uno|una|unos|unas|de|des|del|d\')(\s+|\b)/g;
+var citeKeyTitleBannedRe = /\b(a|an|the|some|from|on|in|to|of|do|with|der|die|das|ein|eine|einer|eines|einem|einen|un|une|la|le|l\'|el|las|los|al|uno|una|unos|unas|de|des|del|d\')(\s+|\b)|(<\/?(i|b|sup|sub|sc|span style=\"small-caps\"|span)>)/g;
 var citeKeyConversionsRe = /%([a-zA-Z])/;
 var citeKeyCleanRe = /[^a-z0-9\!\$\&\*\+\-\.\/\:\;\<\>\?\[\]\^\_\`\|]+/g;
 


### PR DESCRIPTION
Markup will be excluded from keys. This matches the behaviour of BibTeX.js as of https://github.com/zotero/translators/commit/6d3e71da1b166d2457de8784336db99952b488e3

This addresses https://github.com/zotero/translators/issues/1032 and makes the BibLaTeX export compatible with [Pandoc](http://pandoc.org/).